### PR TITLE
Require any Codeception release in 2.0.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
 	    "php": ">=5.4.0",
-        "codeception/codeception": "2.0.0",
+        "codeception/codeception": "~2.0.0",
         "allure-framework/allure-php-api": "~1.1.0"
     },
     "autoload": {


### PR DESCRIPTION
Require any Codeception release in 2.0.x branch instead of exact 2.0.0 version.
Fix #6.
