### PR TITLE
Update readme.md and simplified internal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,35 @@ In order to use this adapter you need to add a new dependency to your **composer
     }
 }
 ```
-To enable this adapter in Codeception tests simply enabled it in extensions section of **codeception.yml**:
+To enable this adapter in Codeception tests simply put it in "enabled" extensions section of **codeception.yml**:
 ```yaml
 extensions:
-    enabled: [Yandex\Allure\Adapter\AllureAdapter]
+    enabled:
+        - Yandex\Allure\Adapter\AllureAdapter
+    config:
+        Yandex\Allure\Adapter\AllureAdapter:
+            deletePreviousResults: false
+            outputDirectory: allure-results
 ```
+
+`deletePreviousResults` will clear all `.xml` files from output directory (this
+behavior may change to complete cleanup later). It is set to `false` by default.
+
+`outputDirectory` is used to store Allure results and will be calculated
+relatively to Codeception output directory (also known as `paths: log` in
+codeception.yml) unless you specify an absolute path. You can traverse up using
+`..` as usual. `outputDirectory` defaults to `allure-results`.
+
+To generate report from your favourite terminal,
+[install](https://github.com/allure-framework/allure-cli#installation)
+allure-cli and run following command (assuming you're in project root and using
+default configuration):
+
+```bash
+allure generate --report-version 1.4.5 --report-path tests/_output/allure-report -- tests/_output/allure-results
+```
+
+Report will be generated in `tests/_output/allure-report`.
 
 ## Main features
 See respective [PHPUnit](https://github.com/allure-framework/allure-phpunit#advanced-features) section.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
     "require": {
 	    "php": ">=5.4.0",
         "codeception/codeception": "~2.0.0",
-        "allure-framework/allure-php-api": "~1.1.0"
+        "allure-framework/allure-php-api": "~1.1.0",
+        "symfony/filesystem": "~2.6",
+        "symfony/finder": "~2.6"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
* Simply described how this extension is configured in README.md
* Refactored internal output directory path calculation, everything is looking good, but i still was testing it by hand
* Only `.xml` files are cleaned from output directory if configuration specifies previous results cleanup. This can be fixed in case this is not desired behavior.