### PR TITLE
hotfix - added missed import of FailEvent

### DIFF
--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -6,6 +6,7 @@ use Codeception\Configuration;
 use Codeception\Event\StepEvent;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
+use Codeception\Event\FailEvent;
 use Codeception\Events;
 use Codeception\Platform\Extension;
 use Codeception\Exception\Configuration as ConfigurationException;


### PR DESCRIPTION
Hotfix for #16: added import of Codeception\Event\FailEvent