### PR TITLE
Update for Codeception 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
 	    "php": ">=5.4.0",
-        "codeception/codeception": "~2.1.0",
+        "codeception/codeception": "~2.1",
         "allure-framework/allure-php-api": "~1.1.0",
         "symfony/filesystem": "~2.6",
         "symfony/finder": "~2.6"

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -9,7 +9,7 @@ use Codeception\Event\TestEvent;
 use Codeception\Event\FailEvent;
 use Codeception\Events;
 use Codeception\Platform\Extension;
-use Codeception\Exception\Configuration as ConfigurationException;
+use Codeception\Exception\ConfigurationException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
 use Yandex\Allure\Adapter\Annotation;


### PR DESCRIPTION
PR for #18 
As I see, there are no breaking changes in new Codeception version related to this adapter. Tested fix in my projects and adapter works fine with 2.2. 
I kept compatibility with 2.1.

Also I fixed namespace import of ConfigurationException, it has been renamed in 2.1, check this https://github.com/Codeception/Codeception/tree/2.1/src/Codeception/Exception 