### PR TITLE
update symfony depends and add annotation label in report

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
 	    "php": ">=5.4.0",
         "codeception/codeception": "~2.1",
         "allure-framework/allure-php-api": "~1.1.0",
-        "symfony/filesystem": "~2.6",
-        "symfony/finder": "~2.6"
+        "symfony/filesystem": ">=2.6",
+        "symfony/finder": ">=2.6"
     },
     "autoload": {
         "psr-0": {

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -198,10 +198,11 @@ class AllureAdapter extends Extension
     {
         $test = $testEvent->getTest();
         $testName = $test->getName();
+        $testClassName = $test->getName(false);
         $className = get_class($test);
         $event = new TestCaseStartedEvent($this->uuid, $testName);
-        if (method_exists($className, $testName)){
-            $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getMethodAnnotations($className, $testName));
+        if (method_exists($className, $testClassName)){
+            $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getMethodAnnotations($className, $testClassName));
             $annotationManager->updateTestCaseEvent($event);
         }
         $this->getLifecycle()->fire($event);


### PR DESCRIPTION
Now adapter can use symfony/filesystem version v2.6.0 - v2.8.9. Updated and tested on version 
symfony/filesystem v3.1.6 and symfony/finder v3.1.6.

And fixed annotation label.