### PR TITLE
Add support for custom ignored annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ extensions:
         Yandex\Allure\Adapter\AllureAdapter:
             deletePreviousResults: false
             outputDirectory: allure-results
+            ignoredAnnotations:
+                - env
+                - dataprovider
 ```
 
 `deletePreviousResults` will clear all `.xml` files from output directory (this
@@ -36,6 +39,8 @@ behavior may change to complete cleanup later). It is set to `false` by default.
 relatively to Codeception output directory (also known as `paths: log` in
 codeception.yml) unless you specify an absolute path. You can traverse up using
 `..` as usual. `outputDirectory` defaults to `allure-results`.
+
+`ignoredAnnotations` is used to define extra custom annotations to ignore. It is empty by default.
 
 To generate report from your favourite terminal,
 [install](https://github.com/allure-framework/allure-cli#installation)

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -28,6 +28,7 @@ use Yandex\Allure\Adapter\Model;
 
 const OUTPUT_DIRECTORY_PARAMETER = 'outputDirectory';
 const DELETE_PREVIOUS_RESULTS_PARAMETER = 'deletePreviousResults';
+const IGNORED_ANNOTATION_PARAMETER = 'ignoredAnnotations';
 const DEFAULT_RESULTS_DIRECTORY = 'allure-results';
 const DEFAULT_REPORT_DIRECTORY = 'allure-report';
 const INITIALIZED_PARAMETER = '_initialized';
@@ -82,6 +83,7 @@ class AllureAdapter extends Extension
         // Add standard PHPUnit annotations
         Annotation\AnnotationProvider::addIgnoredAnnotations($this->ignoredAnnotations);
         // Add custom ignored annotations
+        $ignoredAnnotations = $this->tryGetOption(IGNORED_ANNOTATION_PARAMETER, []);
         Annotation\AnnotationProvider::addIgnoredAnnotations($ignoredAnnotations);
         $outputDirectory = $this->getOutputDirectory();
         $deletePreviousResults =


### PR DESCRIPTION
Currently, custom ignored annotations are not added, hence an exception can be thrown (i.e. in case of `dataprovider` annotation). I suggest to add support for custom ignored annotations, as defined in configuration file.

Fixes #32 