### PR TITLE
A fix for data driven tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,10 @@
         "email": "allure@yandex-team.ru",
         "source": "https://github.com/allure-framework/allure-codeception"
     },
+    "prefer-stable" : true,
     "require": {
 	    "php": ">=5.4.0",
-        "codeception/codeception": "~2.1",
+        "codeception/codeception": "~2.3",
         "allure-framework/allure-php-api": "~1.1.0",
         "symfony/filesystem": ">=2.6",
         "symfony/finder": ">=2.6"

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -279,7 +279,7 @@ class AllureAdapter extends Extension
             $currentExample = $test->getMetadata()->getCurrent();
             if ($currentExample && isset($currentExample['example']) ) {
                 foreach ($currentExample['example'] as $name => $param) {
-                    $paramEvent = new Event\AddParameterEvent($name, $param, ParameterKind::ARGUMENT);
+                    $paramEvent = new Event\AddParameterEvent($name, $this->stringifyArgument($param), ParameterKind::ARGUMENT);
                     $this->getLifecycle()->fire($paramEvent);
                 }
             }
@@ -291,7 +291,7 @@ class AllureAdapter extends Extension
                 $paramNames = $testMethod->getParameters();
                 foreach ($method->invoke($test) as $key => $param) {
                     $paramName = array_shift($paramNames);
-                    $paramEvent = new Event\AddParameterEvent(is_null($paramName) ? $key : $paramName->getName() , $param, ParameterKind::ARGUMENT);
+                    $paramEvent = new Event\AddParameterEvent(is_null($paramName) ? $key : $paramName->getName() , $this->stringifyArgument($param), ParameterKind::ARGUMENT);
                     $this->getLifecycle()->fire($paramEvent);
                 }
             }
@@ -459,4 +459,44 @@ class AllureAdapter extends Extension
         return $parts;
     }
 
+    protected function stringifyArgument($argument)
+    {
+        if (is_string($argument)) {
+            return '"' . strtr($argument, ["\n" => '\n', "\r" => '\r', "\t" => ' ']) . '"';
+        } elseif (is_resource($argument)) {
+            $argument = (string)$argument;
+        } elseif (is_array($argument)) {
+            foreach ($argument as $key => $value) {
+                if (is_object($value)) {
+                    $argument[$key] = $this->getClassName($value);
+}
+            }
+        } elseif (is_object($argument)) {
+            if (method_exists($argument, '__toString')) {
+                $argument = (string)$argument;
+            } elseif (get_class($argument) == 'Facebook\WebDriver\WebDriverBy') {
+                $argument = Locator::humanReadableString($argument);
+            } else {
+                $argument = $this->getClassName($argument);
+            }
+        }
+
+        return json_encode($argument, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    protected function getClassName($argument)
+    {
+        if ($argument instanceof \Closure) {
+            return 'Closure';
+        } elseif ((isset($argument->__mocked))) {
+            return $this->formatClassName($argument->__mocked);
+        } else {
+            return $this->formatClassName(get_class($argument));
+        }
+    }
+
+    protected function formatClassName($classname)
+    {
+        return trim($classname, "\\");
+    }
 }

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -25,6 +25,7 @@ use Yandex\Allure\Adapter\Event\TestCaseStartedEvent;
 use Yandex\Allure\Adapter\Event\TestSuiteFinishedEvent;
 use Yandex\Allure\Adapter\Event\TestSuiteStartedEvent;
 use Yandex\Allure\Adapter\Model;
+use Yandex\Allure\Adapter\Model\ParameterKind;
 
 const OUTPUT_DIRECTORY_PARAMETER = 'outputDirectory';
 const DELETE_PREVIOUS_RESULTS_PARAMETER = 'deletePreviousResults';
@@ -45,7 +46,6 @@ class AllureAdapter extends Extension
     static $events = [
         Events::SUITE_BEFORE => 'suiteBefore',
         Events::SUITE_AFTER => 'suiteAfter',
-        Events::TEST_BEFORE => 'testBefore',
         Events::TEST_START => 'testStart',
         Events::TEST_FAIL => 'testFail',
         Events::TEST_ERROR => 'testError',
@@ -217,37 +217,37 @@ class AllureAdapter extends Extension
         $this->getLifecycle()->fire(new TestSuiteFinishedEvent($this->uuid));
     }
 
-    public function testBefore(TestEvent $testEvent)
-    {
-        $test = $testEvent->getTest();
+    private $testInvocations = array();
+    private function buildTestName($test) {
         $testName = $test->getName();
-        $event = new TestCaseStartedEvent($this->uuid, $testName);
         if ($test instanceof \Codeception\Test\Cest) {
-            $testClass = get_class($test->getTestClass());
-            if (class_exists($testClass, false)) {
-                $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getClassAnnotations($testClass));
-                $annotationManager->updateTestCaseEvent($event);
+            $testFullName = get_class($test->getTestClass()) . '::' . $testName;
+            if(isset($this->testInvocations[$testFullName])) {
+                $this->testInvocations[$testFullName]++;
+            } else {
+                $this->testInvocations[$testFullName] = 0;
             }
-        } else if ($test instanceof \Codeception\Test\Cept) {
-            $annotations = $this->getCeptAnnotations($test);
-            if (count($annotations) > 0) {
-                $annotationManager = new Annotation\AnnotationManager($annotations);
-                $annotationManager->updateTestCaseEvent($event);
+            $currentExample = $test->getMetadata()->getCurrent();
+            if ($currentExample && isset($currentExample['example']) ) {
+                $testName .= ' with data set #' . $this->testInvocations[$testFullName];
             }
         }
-        
-        $this->getLifecycle()->fire($event);
+        return $testName;
     }
     
     public function testStart(TestEvent $testEvent)
     {
         $test = $testEvent->getTest();
-        $testName = $test->getName();
-        $event = new TestCaseStartedEvent($this->uuid, $testName);
+        $testName = $this->buildTestName($test);
+        $event = new TestCaseStartedEvent($this->uuid, $testName);        
         if ($test instanceof \Codeception\Test\Cest) {
             $className = get_class($test->getTestClass());
-            if (method_exists($className, $testName)){
-                $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getMethodAnnotations($className, $testName));
+            if (class_exists($className, false)) {
+                $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getClassAnnotations($className));
+                $annotationManager->updateTestCaseEvent($event);
+            }
+            if (method_exists($className, $test->getName())){
+                $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getMethodAnnotations($className, $test->getName()));
                 $annotationManager->updateTestCaseEvent($event);
             }
         } else if ($test instanceof \Codeception\Test\Cept) {
@@ -256,9 +256,45 @@ class AllureAdapter extends Extension
                 $annotationManager = new Annotation\AnnotationManager($annotations);
                 $annotationManager->updateTestCaseEvent($event);
             }
+        } else if ($test instanceof \PHPUnit_Framework_TestCase) {
+            $methodName = $this->methodName = $test->getName(false);
+            $className = get_class($test);
+            if (class_exists($className, false)) {
+                $annotationManager = new Annotation\AnnotationManager(
+                    Annotation\AnnotationProvider::getClassAnnotations($className)
+                );
+                $annotationManager->updateTestCaseEvent($event);
+            }
+            if (method_exists($test, $methodName)) {
+                $annotationManager = new Annotation\AnnotationManager(
+                    Annotation\AnnotationProvider::getMethodAnnotations(get_class($test), $methodName)
+                );
+                $annotationManager->updateTestCaseEvent($event);
+            }
         }
-        
         $this->getLifecycle()->fire($event);
+
+        if ($test instanceof \Codeception\Test\Cest) {
+            $currentExample = $test->getMetadata()->getCurrent();
+            if ($currentExample && isset($currentExample['example']) ) {
+                foreach ($currentExample['example'] as $name => $param) {
+                    $paramEvent = new Event\AddParameterEvent($name, $param, ParameterKind::ARGUMENT);
+                    $this->getLifecycle()->fire($paramEvent);
+                }
+            }
+        } else if ($test instanceof \PHPUnit_Framework_TestCase) {
+            if ($test->usesDataProvider()) {
+                $method = new \ReflectionMethod(get_class($test), 'getProvidedData');
+                $method->setAccessible(true);
+                $testMethod = new \ReflectionMethod(get_class($test), $test->getName(false));
+                $paramNames = $testMethod->getParameters();
+                foreach ($method->invoke($test) as $key => $param) {
+                    $paramName = array_shift($paramNames);
+                    $paramEvent = new Event\AddParameterEvent(is_null($paramName) ? $key : $paramName->getName() , $param, ParameterKind::ARGUMENT);
+                    $this->getLifecycle()->fire($paramEvent);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -27,6 +27,7 @@ use Yandex\Allure\Adapter\Event\TestSuiteStartedEvent;
 use Yandex\Allure\Adapter\Model;
 use Yandex\Allure\Adapter\Model\ParameterKind;
 
+const ARGUMENTS_LENGTH = 'arguments_length';
 const OUTPUT_DIRECTORY_PARAMETER = 'outputDirectory';
 const DELETE_PREVIOUS_RESULTS_PARAMETER = 'deletePreviousResults';
 const DEFAULT_RESULTS_DIRECTORY = 'allure-results';
@@ -348,8 +349,14 @@ class AllureAdapter extends Extension
 
     public function stepBefore(StepEvent $stepEvent)
     {
-        $stepAction = $stepEvent->getStep()->__toString();
-        $this->getLifecycle()->fire(new StepStartedEvent($stepAction));
+        $stepAction = $stepEvent->getStep()->getHumanizedActionWithoutArguments();
+        $argumentsLength = $this->tryGetOption(ARGUMENTS_LENGTH, 200);
+        $stepArgs = $stepEvent->getStep()->getArgumentsAsString($argumentsLength);
+        $stepName = $stepAction . ' ' . $stepArgs;
+
+        //Workaround for https://github.com/allure-framework/allure-core/issues/442
+        $stepName = str_replace('.', '•', $stepName);
+        $this->getLifecycle()->fire(new StepStartedEvent($stepName));
     }
 
     public function stepAfter()

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class AcceptanceTester extends \Codeception\Actor
+{
+    use _generated\AcceptanceTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Acceptance extends \Codeception\Module
+{
+
+}

--- a/tests/_support/_generated/.gitignore
+++ b/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -1,0 +1,12 @@
+# Codeception Test Suite Configuration
+#
+# Suite for acceptance tests.
+# Perform tests in browser using the WebDriver or PhpBrowser.
+# If you need both WebDriver and PHPBrowser tests - create a separate suite.
+
+actor: AcceptanceTester
+modules:
+    enabled:
+        - PhpBrowser:
+            url: http://localhost/myapp
+        - \Helper\Acceptance

--- a/tests/acceptance/ExampleCest.php
+++ b/tests/acceptance/ExampleCest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\Assert;
+use Yandex\Allure\Adapter\Annotation\Description;
+
+class ExampleCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    /**
+     *
+     * @Description("Free text description in annotation")
+     * @param AcceptanceTester $I
+     * @example {"example_name" : "example 1", "data": "String data for example 1"}
+     * @example {"example_name" : "example 2", "data": "String data for example 2"}
+     */
+    public function tryToTestExamples(AcceptanceTester $I, Codeception\Example $example)
+    {
+        Assert::assertStringEndsWith($example['example_name'], $example['data'], "Assertion comment");
+    }
+
+    public function tryToTestNoExamples(AcceptanceTester $I)
+    {
+        Assert::assertTrue(TRUE, "True is always true");
+    }
+
+}

--- a/tests/acceptance/ParametrisedTest.php
+++ b/tests/acceptance/ParametrisedTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+
+/**
+ * @Description("A parametrised test class description")
+ * https://www.startutorial.com/articles/view/phpunit-beginner-part-2-data-provider
+ */
+class ParametrisedTest extends PHPUnit_Framework_TestCase
+{
+
+    public function addDataProvider() {
+        return array(
+            array(1,2,3),
+            array(0,0,10),
+            array(-1,-1,-2),
+        );
+    }
+
+    /**
+     * @dataProvider addDataProvider
+     * @Title("My Parametrised Test Method Title")
+     */
+    public function testAdd($a, $b, $expected)
+    {
+        $result = $a + $b;
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Free text description in annotation
+     * @Title("My Not Parametrised Title")
+     */
+    public function testSubstruct()
+    {
+        $this->assertEquals(2, 5-3);
+    }
+
+    /**
+     * @Title("My Not Parametrised Title")
+     */
+    public function testFailMultiplication()
+    {
+        $this->assertEquals(5, 2*2);
+    }
+
+}

--- a/tests/acceptance/UnstructuredCept.php
+++ b/tests/acceptance/UnstructuredCept.php
@@ -1,0 +1,2 @@
+<?php
+PHPUnit\Framework\Assert::assertTrue(TRUE, "True is always true");

--- a/tests/acceptance/UnstructuredFailingCept.php
+++ b/tests/acceptance/UnstructuredFailingCept.php
@@ -1,0 +1,2 @@
+<?php
+PHPUnit\Framework\Assert::assertFalse(TRUE, "True is false");

--- a/tests/codeception.yml
+++ b/tests/codeception.yml
@@ -1,0 +1,21 @@
+settings:
+    colors: true
+    memory_limit: 2048M
+    strict_xml: true
+    log_incomplete_skipped: true
+    lint: false
+paths:
+    tests: .
+    output: ./_output
+    data: ./_data
+    support: ./_support
+    envs: ./_envs
+actor_suffix: Tester
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed
+        - Yandex\Allure\Adapter\AllureAdapter
+    config:
+        Yandex\Allure\Adapter\AllureAdapter:
+            deletePreviousResults: true
+            outputDirectory: allure-results

--- a/tests/run-n-report.sh
+++ b/tests/run-n-report.sh
@@ -1,0 +1,5 @@
+export XDEBUG_CONFIG="idekey=netbeans-xdebug"
+vendor/bin/codecept run --config=tests/codeception.yml acceptance
+allure generate -o tests/_output/allure-report -- tests/_output/allure-results/
+allure report open --report-dir tests/_output/allure-report
+


### PR DESCRIPTION
! wait, more work is going to be done to fix some issues existing in this PR. Issues are mostly to do with non string logging which crashes conversion to xml once it gets to it. !

Hi, have a look. Two commits are here. 
https://github.com/nicholascus/allure-codeception/commit/f3affe5b82f1e4fc5ad0eba39e215ac76e71b2af adds parameterisation support on all kinds of tests for allure adapter.
 
https://github.com/nicholascus/allure-codeception/commit/24f2982e6b98ec2661ca2c98dfc0e3bcd41d1e77 adds a codeception example project to use for adapter validation. run tests/run-n-repport.sh

<img width="565" alt="image" src="https://user-images.githubusercontent.com/1756853/31932632-8f13e1c8-b8f2-11e7-9359-ea22f5b3717f.png">

<img width="570" alt="image" src="https://user-images.githubusercontent.com/1756853/31932662-a4cdff6c-b8f2-11e7-8a75-5b426d08443e.png">

