### PR TITLE
Fix example tests

### DIFF
--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -246,11 +246,13 @@ class AllureAdapter extends Extension
         if ($test instanceof \Codeception\Test\Cest) {
             $className = get_class($test->getTestClass());
             if (class_exists($className, false)) {
-                $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getClassAnnotations($className));
+                $annotationManager = new Annotation\AnnotationManager(
+                        Annotation\AnnotationProvider::getClassAnnotations($className));
                 $annotationManager->updateTestCaseEvent($event);
             }
             if (method_exists($className, $test->getName())){
-                $annotationManager = new Annotation\AnnotationManager(Annotation\AnnotationProvider::getMethodAnnotations($className, $test->getName()));
+                $annotationManager = new Annotation\AnnotationManager(
+                        Annotation\AnnotationProvider::getMethodAnnotations($className, $test->getName()));
                 $annotationManager->updateTestCaseEvent($event);
             }
         } else if ($test instanceof \Codeception\Test\Cept) {
@@ -281,7 +283,8 @@ class AllureAdapter extends Extension
             $currentExample = $test->getMetadata()->getCurrent();
             if ($currentExample && isset($currentExample['example']) ) {
                 foreach ($currentExample['example'] as $name => $param) {
-                    $paramEvent = new Event\AddParameterEvent($name, $this->stringifyArgument($param), ParameterKind::ARGUMENT);
+                    $paramEvent = new Event\AddParameterEvent(
+                            $name, $this->stringifyArgument($param), ParameterKind::ARGUMENT);
                     $this->getLifecycle()->fire($paramEvent);
                 }
             }
@@ -293,7 +296,12 @@ class AllureAdapter extends Extension
                 $paramNames = $testMethod->getParameters();
                 foreach ($method->invoke($test) as $key => $param) {
                     $paramName = array_shift($paramNames);
-                    $paramEvent = new Event\AddParameterEvent(is_null($paramName) ? $key : $paramName->getName() , $this->stringifyArgument($param), ParameterKind::ARGUMENT);
+                    $paramEvent = new Event\AddParameterEvent(
+                            is_null($paramName)
+                                ? $key
+                                : $paramName->getName(),
+                            $this->stringifyArgument($param),
+                            ParameterKind::ARGUMENT);
                     $this->getLifecycle()->fire($paramEvent);
                 }
             }

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -27,6 +27,7 @@ use Yandex\Allure\Adapter\Event\TestSuiteStartedEvent;
 use Yandex\Allure\Adapter\Model;
 use Yandex\Allure\Adapter\Model\ParameterKind;
 
+const ARGUMENTS_LENGTH = 'arguments_length';
 const OUTPUT_DIRECTORY_PARAMETER = 'outputDirectory';
 const DELETE_PREVIOUS_RESULTS_PARAMETER = 'deletePreviousResults';
 const IGNORED_ANNOTATION_PARAMETER = 'ignoredAnnotations';
@@ -350,8 +351,14 @@ class AllureAdapter extends Extension
 
     public function stepBefore(StepEvent $stepEvent)
     {
-        $stepAction = $stepEvent->getStep()->__toString();
-        $this->getLifecycle()->fire(new StepStartedEvent($stepAction));
+        $stepAction = $stepEvent->getStep()->getHumanizedActionWithoutArguments();
+        $argumentsLength = $this->tryGetOption(ARGUMENTS_LENGTH, 200);
+        $stepArgs = $stepEvent->getStep()->getArgumentsAsString($argumentsLength);
+        $stepName = $stepAction . ' ' . $stepArgs;
+
+        //Workaround for https://github.com/allure-framework/allure-core/issues/442
+        $stepName = str_replace('.', '•', $stepName);
+        $this->getLifecycle()->fire(new StepStartedEvent($stepName));
     }
 
     public function stepAfter()

--- a/src/Yandex/Allure/Adapter/AllureAdapter.php
+++ b/src/Yandex/Allure/Adapter/AllureAdapter.php
@@ -199,7 +199,7 @@ class AllureAdapter extends Extension
             $filesystem->remove($files);
         }
     }
-    
+
     public function suiteBefore(SuiteEvent $suiteEvent)
     {
         $suite = $suiteEvent->getSuite();
@@ -234,10 +234,12 @@ class AllureAdapter extends Extension
             if ($currentExample && isset($currentExample['example']) ) {
                 $testName .= ' with data set #' . $this->testInvocations[$testFullName];
             }
+        } else if($test instanceof \Codeception\Test\Gherkin) {
+            $testName = $test->getMetadata()->getFeature();
         }
         return $testName;
     }
-    
+
     public function testStart(TestEvent $testEvent)
     {
         $test = $testEvent->getTest();


### PR DESCRIPTION
Records all invocations of Cest @example driven tests and PHPUnit data provider driven tests execution  by Codeception as individual tests. Before only one record for parametrised method was created.

<img width="570" alt="image" src="https://user-images.githubusercontent.com/1756853/31932662-a4cdff6c-b8f2-11e7-8a75-5b426d08443e.png">

