### PR TITLE
Check if test is codeception test

### DIFF
--- a/src/Yandex/Allure/Codeception/AllureCodeception.php
+++ b/src/Yandex/Allure/Codeception/AllureCodeception.php
@@ -382,7 +382,7 @@ class AllureCodeception extends Extension
     public function testEnd(TestEvent $testEvent)
     {
         // attachments supported since Codeception 3.0
-        if (version_compare(Codecept::VERSION, '3.0.0') > -1) {
+        if (version_compare(Codecept::VERSION, '3.0.0') > -1 && $testEvent->getTest() instanceof Cest) {
             $artifacts = $testEvent->getTest()->getMetadata()->getReports();
             $testCaseStorage = $this->getLifecycle()->getTestCaseStorage()->get();
             foreach ($artifacts as $name => $artifact) {


### PR DESCRIPTION
In case if I'm running PHPUnit test which is starting by Codeception I will have an exception case there is no metadata in PHPUnit tests. 

If you look for metadata getters in this file - you'll see they are all under 'instance of' check.