### PR TITLE
Add ability to install with codeception 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
 	    "php": ">=5.4.0",
-        "codeception/codeception": "^2.3|^3.0",
+        "codeception/codeception": "^2.3|^3.0|^4.0",
         "allure-framework/allure-php-api": "~1.1.0",
         "symfony/filesystem": ">=2.6",
         "symfony/finder": ">=2.6"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
 	    "php": ">=5.4.0",
-        "codeception/codeception": "~2.1",
+        "codeception/codeception": "^2.3|^3.0",
         "allure-framework/allure-php-api": "~1.1.0",
         "symfony/filesystem": ">=2.6",
         "symfony/finder": ">=2.6"

--- a/src/Yandex/Allure/Codeception/AllureCodeception.php
+++ b/src/Yandex/Allure/Codeception/AllureCodeception.php
@@ -382,7 +382,7 @@ class AllureCodeception extends Extension
     public function testEnd(TestEvent $testEvent)
     {
         // attachments supported since Codeception 3.0
-        if (version_compare(Codecept::VERSION, '3.0.0') > -1) {
+        if (version_compare(Codecept::VERSION, '3.0.0') > -1 && $testEvent->getTest() instanceof Cest) {
             $artifacts = $testEvent->getTest()->getMetadata()->getReports();
             $testCaseStorage = $this->getLifecycle()->getTestCaseStorage()->get();
             foreach ($artifacts as $name => $artifact) {


### PR DESCRIPTION
- Add ability to install with codeception 4
- Made a fork, and play with it, it works pretty well and compatible with this 4.* version of the framework 
- Also there is such kind of issue in repo https://github.com/allure-framework/allure-codeception/issues/50