### PR TITLE
fix BuildTestName and add attachment in report for gherkin

### DIFF
--- a/src/Yandex/Allure/Codeception/AllureCodeception.php
+++ b/src/Yandex/Allure/Codeception/AllureCodeception.php
@@ -252,7 +252,7 @@ class AllureCodeception extends Extension
                 $testName .= ' with data set #' . $this->testInvocations[$testFullName];
             }
         } else if($test instanceof Gherkin) {
-            $testName = $test->getMetadata()->getFeature();
+            $testName = $test->getFeatureNode()->getTitle();
         }
         return $testName;
     }
@@ -390,6 +390,11 @@ class AllureCodeception extends Extension
     {
         // attachments supported since Codeception 3.0
         if (version_compare(Codecept::VERSION, '3.0.0') > -1 && $testEvent->getTest() instanceof Cest) {
+            $artifacts = $testEvent->getTest()->getMetadata()->getReports();
+            foreach ($artifacts as $name => $artifact) {
+                Allure::lifecycle()->fire(new AddAttachmentEvent($artifact, $name, null));
+            }
+        } elseif (version_compare(Codecept::VERSION, '3.0.0') > -1 && $testEvent->getTest() instanceof Gherkin) {
             $artifacts = $testEvent->getTest()->getMetadata()->getReports();
             foreach ($artifacts as $name => $artifact) {
                 Allure::lifecycle()->fire(new AddAttachmentEvent($artifact, $name, null));


### PR DESCRIPTION
Codeception 3.0.2 + Behat/gherkin 4.4.0 + Allure-codeception 1.4.0
1. I fixed generate allure-report with testName scenario instead testName feature 
Details to buildTestName here:
https://github.com/allure-framework/allure-codeception/issues/70
2.I added able in Allure generate report with attachments for gherkin


