### PR TITLE
Update AllureCodeception.php

### DIFF
--- a/src/AllureCodeception.php
+++ b/src/AllureCodeception.php
@@ -68,7 +68,7 @@ final class AllureCodeception extends Extension
      * @throws ConfigurationException
      * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
      */
-    public function moduleInit(): void
+    public function _initialize(): void
     {
         QametaAllure::reset();
         $this->testLifecycle = null;

--- a/src/AllureCodeception.php
+++ b/src/AllureCodeception.php
@@ -44,7 +44,6 @@ final class AllureCodeception extends Extension
     private const DEFAULT_RESULTS_DIRECTORY = 'allure-results';
 
     protected static array $events = [
-        Events::MODULE_INIT => 'moduleInit',
         Events::SUITE_BEFORE => 'suiteBefore',
         Events::SUITE_AFTER => 'suiteAfter',
         Events::TEST_START => 'testStart',


### PR DESCRIPTION
refers to #123

`moduleInit` method is never called at initialization. Instead, there is `_initialize` method that is used by other modules in Codeception.

```
In LifecycleBuilder.php line 87:
                                                                                                                                                   
  [Qameta\Allure\Exception\OutputDirectoryUndefinedException]                                                                                      
  Output directory is not set for Allure. Please call Qameta\Allure\Allure::setOutputDirectory() method before accessing Allure lifecycle object.  
                                                                                                                                                   

Exception trace:
  at /var/www/yclients/vendor/allure-framework/allure-php-commons/src/Internal/LifecycleBuilder.php:87
 Qameta\Allure\Internal\LifecycleBuilder->getOutputDirectory() at /var/www/yclients/vendor/allure-framework/allure-php-commons/src/Internal/LifecycleBuilder.php:80
 Qameta\Allure\Internal\LifecycleBuilder->createResultsWriter() at /var/www/yclients/vendor/allure-framework/allure-php-commons/src/Allure.php:338
 Qameta\Allure\Allure->getResultsWriter() at /var/www/yclients/vendor/allure-framework/allure-php-commons/src/Allure.php:306
 Qameta\Allure\Allure->doGetLifecycle() at /var/www/yclients/vendor/allure-framework/allure-php-commons/src/Allure.php:291
 Qameta\Allure\Allure::getLifecycle() at /var/www/yclients/vendor/allure-framework/allure-codeception/src/AllureCodeception.php:299
 Qameta\Allure\Codeception\AllureCodeception->getTestLifecycle() at /var/www/yclients/vendor/allure-framework/allure-codeception/src/AllureCodeception.php:155
 Qameta\Allure\Codeception\AllureCodeception->suiteBefore() at /var/www/yclients/vendor/symfony/event-dispatcher/EventDispatcher.php:220
 Symfony\Component\EventDispatcher\EventDispatcher->callListeners() at /var/www/yclients/vendor/symfony/event-dispatcher/EventDispatcher.php:56
 Symfony\Component\EventDispatcher\EventDispatcher->dispatch() at /var/www/yclients/vendor/codeception/codeception/src/Codeception/SuiteManager.php:148
 Codeception\SuiteManager->run() at /var/www/yclients/vendor/codeception/codeception/src/Codeception/Codecept.php:260
 Codeception\Codecept->runSuite() at /var/www/yclients/vendor/codeception/codeception/src/Codeception/Codecept.php:216
 Codeception\Codecept->run() at /var/www/yclients/vendor/codeception/codeception/src/Codeception/Command/Run.php:646
 Codeception\Command\Run->runSuites() at /var/www/yclients/vendor/codeception/codeception/src/Codeception/Command/Run.php:467
 Codeception\Command\Run->execute() at /var/www/yclients/vendor/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at /var/www/yclients/vendor/symfony/console/Application.php:1078
 Symfony\Component\Console\Application->doRunCommand() at /var/www/yclients/vendor/symfony/console/Application.php:324
 Symfony\Component\Console\Application->doRun() at /var/www/yclients/vendor/symfony/console/Application.php:175
 Symfony\Component\Console\Application->run() at /var/www/yclients/vendor/codeception/codeception/src/Codeception/Application.php:112
 Codeception\Application->run() at /var/www/yclients/vendor/codeception/codeception/app.php:45
 {closure}() at /var/www/yclients/vendor/codeception/codeception/app.php:46
 require() at /var/www/yclients/vendor/codeception/codeception/codecept:7
 include() at /var/www/yclients/bin/codecept:119
```

Codeception version is 5.0.13