### PR TITLE
PHP 8.4 deprecation fixes

### DIFF
--- a/test/codeception-report/unit/StepsTest.php
+++ b/test/codeception-report/unit/StepsTest.php
@@ -91,7 +91,7 @@ class StepsTest extends Unit
                 $this->failure = $failure;
             }
 
-            public function run(ModuleContainer $container = null): void
+            public function run(?ModuleContainer $container = null): void
             {
                 $this->setFailed(true);
                 Unit::fail($this->failure);


### PR DESCRIPTION
Prominent deprecation in PHP 8.4:
This is a prominent deprecation in PHP 8.4 and legacy PHP applications will likely cause deprecation notices due to this change in PHP 8.4. The [suggested replacement](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated#change) is straight-forward, safe, and works in PHP 7.1 and later.