### PR TITLE
Update dev deps and CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           - "--prefer-lowest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - 'main'
       - 'hotfix-*'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Test on ${{ matrix.os }} php${{ matrix.php-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tests:
     name: Test on ${{ matrix.os }} php${{ matrix.php-version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
@@ -22,9 +22,9 @@ jobs:
           - "8.2"
           - "8.3"
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macOS-latest
+          - ubuntu
+          - windows
+          - macOS
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,30 @@ permissions:
   contents: read
 
 jobs:
+  static-checks:
+    name: Run static checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Validate composer.json
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Run PHP_CodeSniffer
+        run: vendor/bin/phpcs -sp
+
+      - name: Run Psalm
+        run: vendor/bin/psalm --shepherd
+
   tests:
     name: Test on ${{ matrix.os }} php${{ matrix.php-version }}
     runs-on: ${{ matrix.os }}-latest
@@ -41,9 +65,6 @@ jobs:
           coverage: xdebug
           ini-values: error_reporting=E_ALL
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress
 
@@ -54,5 +75,11 @@ jobs:
           )**" >> "$GITHUB_STEP_SUMMARY"
         shell: bash
 
-      - name: Run tests
-        run: composer test
+      - name: Run unit tests tests
+        run: composer test-unit
+
+      - name: Run samples
+        run: composer test-report-generate
+
+      - name: Assert samples
+        run: composer test-report-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,12 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress
 
+      - name: Show Codeception version
+        run: |
+          echo "Tested against Codeception **v$(
+            composer show codeception/codeception --format json | jq -r '.versions[0]'
+          )**" >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+
       - name: Run tests
         run: composer test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   static-checks:
     name: Run static checks
@@ -20,10 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up PHP ${{ matrix.php-version }}
+      - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: "8.3"
 
       - name: Validate composer.json
         run: composer validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php-version }} on ${{ matrix.os }} (${{ matrix.composer-options }})
+    name: Test on ${{ matrix.os }} php${{ matrix.php-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,9 +25,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        composer-options:
-          - ""
-          - "--prefer-lowest"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,10 +42,7 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer update
-          --prefer-dist
-          --no-progress
-          ${{ matrix.composer-options }}
+        run: composer update --prefer-dist --no-progress
 
       - name: Run tests
         run: composer test

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: baev/match-label-action@master
         with:
-          allowed: 'type:bug,type:new feature,type:improvement,type:dependencies,type:internal,type:invalid'
+          allowed: 'type:bug,type:new feature,type:improvement,type:dependencies,type:internal,type:invalid,type:docs'

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
         "allure-framework/allure-php-commons": "^2.3.1"
     },
     "require-dev": {
-        "psalm/plugin-phpunit": "^0.19.0",
+        "psalm/plugin-phpunit": "^0.19.0 || ^0.20.1",
         "remorhaz/php-json-data": "^0.5.3",
         "remorhaz/php-json-path": "^0.7.7",
         "squizlabs/php_codesniffer": "^4.0.1",
-        "vimeo/psalm": "^5.12"
+        "vimeo/psalm": "^5.26.1 || ^6.16.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psalm/plugin-phpunit": "^0.19.0",
         "remorhaz/php-json-data": "^0.5.3",
         "remorhaz/php-json-path": "^0.7.7",
-        "squizlabs/php_codesniffer": "^3.7.2",
+        "squizlabs/php_codesniffer": "^4.0.1",
         "vimeo/psalm": "^5.12"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,8 @@
 
     <file>src</file>
     <file>test</file>
+    <exclude-pattern>test/codeception/_support/_generated/*</exclude-pattern>
+    <exclude-pattern>test/codeception-report/_support/_generated/*</exclude-pattern>
 
     <arg name="colors"/>
 

--- a/src/Internal/GherkinProvider.php
+++ b/src/Internal/GherkinProvider.php
@@ -36,8 +36,8 @@ final class GherkinProvider implements ModelProviderInterface
         return array_map(
             fn (string $value) => Label::feature($value),
             [
-                ...array_values($this->test->getFeatureNode()->getTags()),
-                ...array_values($this->test->getScenarioNode()->getTags()),
+                ...$this->test->getFeatureNode()->getTags(),
+                ...$this->test->getScenarioNode()->getTags(),
             ],
         );
     }

--- a/src/Internal/UnitInfoBuilder.php
+++ b/src/Internal/UnitInfoBuilder.php
@@ -22,10 +22,15 @@ final class UnitInfoBuilder implements TestInfoBuilderInterface
         $index = $this->test->getMetadata()->getIndex();
         $dataLabel = is_int($index) ? "#$index" : $index;
 
+        /**
+         * @var null|string
+         */
+        $class = $fields['class'];
+
         return new TestInfo(
             originalTest: $this->test,
             signature: $this->test->getSignature(),
-            class: $fields['class'] ?? null,
+            class: $class ?? null,
             method: $this->test->getMetadata()->getName(),
             dataLabel: $dataLabel,
             host: $host,

--- a/test/codeception-report/unit/StepsTest.php
+++ b/test/codeception-report/unit/StepsTest.php
@@ -85,6 +85,9 @@ class StepsTest extends Unit
         return new class ($failure, $name) extends Meta {
             private string $failure;
 
+            /**
+             * @param array<array-key, string> $arguments
+             */
             public function __construct(string $failure, string $action, array $arguments = [])
             {
                 parent::__construct($action, $arguments);


### PR DESCRIPTION
The PR contains the following changes:

  - Enable Psalm 6 and psalm/plugin-phpunit 0.20 on newer PHP versions
  - Bump Psalm to `^5.26.1` on older PHP versions
  - Bump PHP code sniffer to `^4.0.1`
  - Fix errors reported by the latest Psalm version
  - Remove `--prefer-lowest` from the CI test pipeline to ease the maintenance burden.
  - Move static checks (`composer validate`, phpcs, and psalm`) to a separate job and always run them on a modern PHP
  - Introduce concurrency to build workflow
  - Make the test CI job titles shorter
  - Display the Codecept version on the CI job summary pages
  - Exclude autogenerated files from PHP code sniffer check
  - Add explicit permissions to both workflows
  - Add the missing `type:docs` label to `labels-verify.yml`