### PR TITLE
Treat errors in setup hooks as Global Errors in Allure Report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ composer.phar
 composer.lock
 /build/
 /test/codeception*/_support/_generated/
+/test/hooks-fixtures/_support/_generated/
 .phpunit.result.cache
 

--- a/codeception-hooks.yml
+++ b/codeception-hooks.yml
@@ -1,0 +1,17 @@
+namespace: Qameta\Allure\Codeception\Test\Hooks
+
+settings:
+  lint: true
+paths:
+  tests: test/hooks-fixtures
+  output: build/hooks-fixtures
+  support: test/hooks-fixtures/_support
+  data: test/hooks-fixtures/_data
+
+extensions:
+  enabled:
+    - Qameta\Allure\Codeception\AllureCodeception
+  config:
+    Qameta\Allure\Codeception\AllureCodeception:
+      outputDirectory: allure-results-hooks
+      setupHook: Qameta\Allure\Codeception\Test\Hooks\Setup\OutputDirectoryHook

--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,18 @@
             "Qameta\\Allure\\Codeception\\Test\\Report\\": "test/codeception-report/_support/",
             "Qameta\\Allure\\Codeception\\Test\\Report\\Functional\\": "test/codeception-report/functional/",
             "Qameta\\Allure\\Codeception\\Test\\Report\\Acceptance\\": "test/codeception-report/acceptance/",
-            "Qameta\\Allure\\Codeception\\Test\\Report\\Unit\\": "test/codeception-report/unit/"
+            "Qameta\\Allure\\Codeception\\Test\\Report\\Unit\\": "test/codeception-report/unit/",
+            "Qameta\\Allure\\Codeception\\Test\\Hooks\\": [
+                "test/hooks-fixtures/_support/",
+                "test/hooks-fixtures/unit/"
+            ]
         }
     },
     "scripts": {
         "build": [
             "vendor/bin/codecept build",
             "vendor/bin/codecept build -c codeception-report.yml",
+            "vendor/bin/codecept build -c codeception-hooks.yml",
             "vendor/bin/codecept gherkin:snippets acceptance -c codeception-report.yml"
         ],
         "test-cs": "vendor/bin/phpcs -sp",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,7 @@
     <file>test</file>
     <exclude-pattern>test/codeception/_support/_generated/*</exclude-pattern>
     <exclude-pattern>test/codeception-report/_support/_generated/*</exclude-pattern>
+    <exclude-pattern>test/hooks-fixtures/_support/_generated/*</exclude-pattern>
 
     <arg name="colors"/>
 

--- a/src/AllureAdapter.php
+++ b/src/AllureAdapter.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception;
+
+final class AllureAdapter implements AllureAdapterInterface
+{
+    private static ?AllureAdapterInterface $instance = null;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $suiteContainers = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $emittedHookGlobals = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $startedTests = [];
+
+    private ?string $activeFixtureUuid = null;
+
+    private ?string $activeHookName = null;
+
+    private function __construct()
+    {
+    }
+
+    public static function getInstance(): AllureAdapterInterface
+    {
+        return self::$instance ??= new self();
+    }
+
+    public static function setInstance(AllureAdapterInterface $instance): void
+    {
+        self::$instance = $instance;
+    }
+
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+
+    #[\Override]
+    public function setActiveFixture(string $uuid, string $hookName): void
+    {
+        $this->activeFixtureUuid = $uuid;
+        $this->activeHookName = $hookName;
+    }
+
+    #[\Override]
+    public function getActiveFixtureUuid(): ?string
+    {
+        return $this->activeFixtureUuid;
+    }
+
+    #[\Override]
+    public function getActiveHookName(): ?string
+    {
+        return $this->activeHookName;
+    }
+
+    #[\Override]
+    public function clearActiveFixture(): void
+    {
+        $this->activeFixtureUuid = null;
+        $this->activeHookName = null;
+    }
+
+    #[\Override]
+    public function hasEmittedHookGlobalError(string $fixtureUuid): bool
+    {
+        return isset($this->emittedHookGlobals[$fixtureUuid]);
+    }
+
+    #[\Override]
+    public function markHookGlobalErrorEmitted(string $fixtureUuid): void
+    {
+        $this->emittedHookGlobals[$fixtureUuid] = true;
+    }
+
+    #[\Override]
+    public function registerSuiteContainer(string $suiteName, string $containerUuid): void
+    {
+        $this->suiteContainers[$suiteName] = $containerUuid;
+    }
+
+    #[\Override]
+    public function getSuiteContainerId(string $suiteName): ?string
+    {
+        return $this->suiteContainers[$suiteName] ?? null;
+    }
+
+    #[\Override]
+    public function clearSuiteContainer(string $suiteName): void
+    {
+        unset($this->suiteContainers[$suiteName]);
+    }
+
+    #[\Override]
+    public function markTestStarted(string $testUuid): void
+    {
+        $this->startedTests[$testUuid] = true;
+    }
+
+    #[\Override]
+    public function wasTestStarted(string $testUuid): bool
+    {
+        return isset($this->startedTests[$testUuid]);
+    }
+
+    #[\Override]
+    public function clearTestStarted(string $testUuid): void
+    {
+        unset($this->startedTests[$testUuid]);
+    }
+}

--- a/src/AllureAdapterInterface.php
+++ b/src/AllureAdapterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception;
+
+interface AllureAdapterInterface
+{
+    public function setActiveFixture(string $uuid, string $hookName): void;
+
+    public function getActiveFixtureUuid(): ?string;
+
+    public function getActiveHookName(): ?string;
+
+    public function clearActiveFixture(): void;
+
+    public function hasEmittedHookGlobalError(string $fixtureUuid): bool;
+
+    public function markHookGlobalErrorEmitted(string $fixtureUuid): void;
+
+    public function registerSuiteContainer(string $suiteName, string $containerUuid): void;
+
+    public function getSuiteContainerId(string $suiteName): ?string;
+
+    public function clearSuiteContainer(string $suiteName): void;
+
+    public function markTestStarted(string $testUuid): void;
+
+    public function wasTestStarted(string $testUuid): bool;
+
+    public function clearTestStarted(string $testUuid): void;
+}

--- a/src/AllureCodeception.php
+++ b/src/AllureCodeception.php
@@ -12,6 +12,7 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Exception\ConfigurationException;
+use PHPUnit\Framework\AssertionFailedError;
 use Qameta\Allure\Allure;
 use Qameta\Allure\Allure as QametaAllure;
 use Qameta\Allure\Codeception\Internal\DefaultThreadDetector;
@@ -22,10 +23,11 @@ use Qameta\Allure\Codeception\Setup\ThreadDetectorInterface;
 use Qameta\Allure\Model\LinkType;
 use Qameta\Allure\Model\Status;
 use Qameta\Allure\Model\StatusDetails;
-use Qameta\Allure\Setup\DefaultStatusDetector;
 use Qameta\Allure\Setup\LinkTemplate;
 use Qameta\Allure\Setup\LinkTemplateInterface;
+use Throwable;
 
+use function array_reverse;
 use function class_exists;
 use function is_a;
 use function is_array;
@@ -35,6 +37,27 @@ use function trim;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * Allure Codeception extension.
+ *
+ * Codeception has no per-hook Called/Failed events. Module hook phases are reported
+ * as Allure fixtures by wrapping SUITE_BEFORE / SUITE_AFTER / TEST_BEFORE / TEST_AFTER
+ * (invoking Module hooks from this extension and stopPropagation so the Module
+ * subscriber does not double-run — required so `_beforeSuite` failures still emit
+ * globals: SuiteManager dispatches SUITE_BEFORE outside its try/finally).
+ *
+ * Fixtures:
+ * - `_beforeSuite` / `_afterSuite` → suite container (beforeClass folded into before)
+ * - `_before` / `_after` → per-test container
+ *
+ * Cannot split Module vs @beforeClass with the extension alone.
+ *
+ * Not wrapped (no Codeception events): Cest `_before`/`_after`/`@before`/`@after`,
+ * Unit setUp/tearDown, step hooks, Module `_failed`.
+ *
+ * Lifecycle: testStart creates/schedules the test but defers startTest until `_before`
+ * succeeds (Prepared-after-hooks alignment with allure-phpunit).
+ */
 final class AllureCodeception extends Extension
 {
     private const SETUP_HOOK_PARAMETER = 'setupHook';
@@ -45,9 +68,20 @@ final class AllureCodeception extends Extension
 
     protected static array $events = [
         Events::MODULE_INIT => 'moduleInit',
-        Events::SUITE_BEFORE => 'suiteBefore',
-        Events::SUITE_AFTER => 'suiteAfter',
+        Events::SUITE_BEFORE => [
+            ['suiteBeforeHookPhase', 100],
+        ],
+        Events::SUITE_AFTER => [
+            ['suiteAfterHookStart', 200],
+            ['suiteAfterModuleWrap', 1],
+        ],
         Events::TEST_START => 'testStart',
+        Events::TEST_BEFORE => [
+            ['testBeforeHookPhase', 100],
+        ],
+        Events::TEST_AFTER => [
+            ['testAfterHookPhase', 100],
+        ],
         Events::TEST_FAIL => 'testFail',
         Events::TEST_ERROR => 'testError',
         Events::TEST_INCOMPLETE => 'testIncomplete',
@@ -55,7 +89,7 @@ final class AllureCodeception extends Extension
         Events::TEST_SUCCESS => 'testSuccess',
         Events::TEST_END => 'testEnd',
         Events::STEP_BEFORE => 'stepBefore',
-        Events::STEP_AFTER => 'stepAfter'
+        Events::STEP_AFTER => 'stepAfter',
     ];
 
     private ?ThreadDetectorInterface $threadDetector = null;
@@ -86,6 +120,7 @@ final class AllureCodeception extends Extension
     private function reconfigure(): void
     {
         QametaAllure::reset();
+        AllureAdapter::reset();
         $this->testLifecycle = null;
         $this->threadDetector = null;
         QametaAllure::getLifecycleConfigurator()
@@ -156,9 +191,12 @@ final class AllureCodeception extends Extension
     }
 
     /**
+     * Wraps `_beforeSuite` (+ beforeClass) because SUITE_BEFORE throws abort SuiteManager
+     * before its try/finally — SUITE_AFTER never runs, so orphan flush cannot help.
+     *
      * @psalm-suppress MissingDependency
      */
-    public function suiteBefore(SuiteEvent $suiteEvent): void
+    public function suiteBeforeHookPhase(SuiteEvent $suiteEvent): void
     {
         /** @psalm-suppress InternalMethod */
         $suiteName = $suiteEvent->getSuite()?->getName();
@@ -166,16 +204,141 @@ final class AllureCodeception extends Extension
             return;
         }
 
-        $this
+        $lifecycle = $this
             ->getTestLifecycle()
-            ->switchToSuite(new SuiteInfo($suiteName));
+            ->switchToSuite(new SuiteInfo($suiteName))
+            ->ensureSuiteContainer()
+            ->startBeforeHookFixture('_beforeSuite');
+
+        try {
+            $this->runBeforeClassMethods($suiteEvent);
+            foreach ($this->getModulesList() as $module) {
+                $module->_beforeSuite($suiteEvent->getSettings());
+            }
+            $lifecycle->completeHookFixtureSuccess();
+        } catch (Throwable $e) {
+            $lifecycle
+                ->completeHookFixtureFailure(
+                    $this->statusForHookThrowable($e),
+                    $e->getMessage(),
+                    $e->getTraceAsString(),
+                )
+                ->writeSuiteContainer()
+                ->resetSuite();
+            throw $e;
+        } finally {
+            $suiteEvent->stopPropagation();
+        }
     }
 
-    public function suiteAfter(): void
+    public function suiteAfterHookStart(): void
     {
+        // Module::_after may throw and skip TEST_END.
         $this
             ->getTestLifecycle()
-            ->resetSuite();
+            ->flushActiveHookFixtureFailure(Status::broken())
+            ->finalizePendingTest()
+            ->ensureSuiteContainer()
+            ->startAfterHookFixture('_afterSuite');
+    }
+
+    /**
+     * Runs Module `_afterSuite` inside the active fixture and stops propagation so
+     * Module subscriber does not double-invoke. afterClass (prio 100) already ran.
+     */
+    public function suiteAfterModuleWrap(SuiteEvent $suiteEvent): void
+    {
+        $lifecycle = $this->getTestLifecycle();
+        try {
+            foreach (array_reverse($this->getModulesList()) as $module) {
+                $module->_afterSuite();
+            }
+            $lifecycle
+                ->completeHookFixtureSuccess()
+                ->writeSuiteContainer()
+                ->resetSuite();
+        } catch (Throwable $e) {
+            $lifecycle
+                ->completeHookFixtureFailure(
+                    $this->statusForHookThrowable($e),
+                    $e->getMessage(),
+                    $e->getTraceAsString(),
+                )
+                ->writeSuiteContainer()
+                ->resetSuite();
+            throw $e;
+        } finally {
+            $suiteEvent->stopPropagation();
+        }
+    }
+
+    /**
+     * Wraps Module `_after` so failures still emit fixture + global (low-prio stop
+     * would be skipped when Module throws; TEST_END would also be skipped).
+     *
+     * @psalm-suppress MissingDependency
+     */
+    public function testAfterHookPhase(TestEvent $testEvent): void
+    {
+        $lifecycle = $this
+            ->getTestLifecycle()
+            ->switchToTest($testEvent->getTest())
+            ->startAfterHookFixture('_after');
+
+        try {
+            foreach (array_reverse($this->getModulesList()) as $module) {
+                $module->_after($testEvent->getTest());
+                $module->_resetConfig();
+            }
+            $lifecycle->completeHookFixtureSuccess();
+        } catch (Throwable $e) {
+            $lifecycle->completeHookFixtureFailure(
+                $this->statusForHookThrowable($e),
+                $e->getMessage(),
+                $e->getTraceAsString(),
+            );
+            throw $e;
+        } finally {
+            $testEvent->stopPropagation();
+        }
+    }
+
+    /**
+     * @return list<\Codeception\Module>
+     */
+    private function getModulesList(): array
+    {
+        $modules = [];
+        foreach ($this->getCurrentModuleNames() as $name) {
+            $modules[] = $this->getModule($name);
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Mirrors Codeception\Subscriber\BeforeAfterTest::beforeClass so it stays inside
+     * the `_beforeSuite` fixture when we stopPropagation on SUITE_BEFORE.
+     */
+    private function runBeforeClassMethods(SuiteEvent $suiteEvent): void
+    {
+        $suite = $suiteEvent->getSuite();
+        if ($suite === null) {
+            return;
+        }
+
+        foreach ($suite->getTests() as $test) {
+            $methods = $test->getMetadata()->getBeforeClassMethods();
+            $target = $test;
+            if ($test instanceof \Codeception\Test\TestCaseWrapper) {
+                $target = $test->getTestCase();
+            }
+            foreach ($methods as $method) {
+                if (is_callable([$target, $method])) {
+                    $target->{$method}();
+                }
+            }
+        }
     }
 
     /**
@@ -188,8 +351,41 @@ final class AllureCodeception extends Extension
             ->getTestLifecycle()
             ->switchToTest($test)
             ->create()
-            ->updateTest()
-            ->startTest();
+            ->updateTest();
+        // startTest deferred until TEST_BEFORE succeeds (Prepared-after-hooks alignment).
+    }
+
+    /**
+     * Wraps Module `_before` using Extension module list. Required because
+     * suiteBeforeHookPhase stopPropagation skips Module::beforeSuite which would
+     * otherwise populate Module subscriber's module list for TEST_BEFORE.
+     *
+     * @psalm-suppress MissingDependency
+     */
+    public function testBeforeHookPhase(TestEvent $testEvent): void
+    {
+        $lifecycle = $this
+            ->getTestLifecycle()
+            ->switchToTest($testEvent->getTest())
+            ->startBeforeHookFixture('_before');
+
+        try {
+            foreach ($this->getModulesList() as $module) {
+                $module->_before($testEvent->getTest());
+            }
+            $lifecycle
+                ->completeHookFixtureSuccess()
+                ->startTest();
+        } catch (Throwable $e) {
+            $lifecycle->completeHookFixtureFailure(
+                $this->statusForHookThrowable($e),
+                $e->getMessage(),
+                $e->getTraceAsString(),
+            );
+            throw $e;
+        } finally {
+            $testEvent->stopPropagation();
+        }
     }
 
     private function getThreadDetector(): ThreadDetectorInterface
@@ -202,11 +398,18 @@ final class AllureCodeception extends Extension
      */
     public function testError(FailEvent $failEvent): void
     {
+        $error = $failEvent->getFail();
+        $status = $this->statusForHookThrowable($error);
         $this
             ->getTestLifecycle()
             ->switchToTest($failEvent->getTest())
+            ->completeOrphanHookFailure(
+                $status,
+                $error->getMessage(),
+                $error->getTraceAsString(),
+            )
             ->updateTestFailure(
-                $failEvent->getFail(),
+                $error,
                 Status::broken(),
             );
     }
@@ -220,8 +423,13 @@ final class AllureCodeception extends Extension
         $this
             ->getTestLifecycle()
             ->switchToTest($failEvent->getTest())
+            ->completeOrphanHookFailure(
+                Status::failed(),
+                $error->getMessage(),
+                $error->getTraceAsString(),
+            )
             ->updateTestFailure(
-                $failEvent->getFail(),
+                $error,
                 Status::failed(),
                 new StatusDetails(message: $error->getMessage(), trace: $error->getTraceAsString()),
             );
@@ -308,6 +516,13 @@ final class AllureCodeception extends Extension
             ->stopStep();
     }
 
+    private function statusForHookThrowable(Throwable $error): Status
+    {
+        return $error instanceof AssertionFailedError
+            ? Status::failed()
+            : Status::broken();
+    }
+
     private function getTestLifecycle(): TestLifecycleInterface
     {
         return $this->testLifecycle ??= new TestLifecycle(
@@ -318,6 +533,7 @@ final class AllureCodeception extends Extension
             threadDetector: $this->getThreadDetector(),
             linkTemplates: Allure::getConfig()->getLinkTemplates(),
             env: $_ENV,
+            adapter: AllureAdapter::getInstance(),
         );
     }
 }

--- a/src/Internal/HookFailureMessage.php
+++ b/src/Internal/HookFailureMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Internal;
+
+use function trim;
+
+/**
+ * @internal
+ */
+final class HookFailureMessage
+{
+    public static function format(string $hookName, ?string $originalMessage): string
+    {
+        $trimmed = trim((string) $originalMessage);
+
+        return $trimmed === ''
+            ? "{$hookName} failed"
+            : "{$hookName} failed: {$trimmed}";
+    }
+}

--- a/src/Internal/TestLifecycle.php
+++ b/src/Internal/TestLifecycle.php
@@ -10,10 +10,13 @@ use Codeception\Test\Cest;
 use Codeception\Test\Gherkin;
 use Codeception\Test\TestCaseWrapper;
 use Codeception\TestInterface;
+use Qameta\Allure\Allure;
 use Qameta\Allure\AllureLifecycleInterface;
+use Qameta\Allure\Codeception\AllureAdapterInterface;
 use Qameta\Allure\Codeception\Setup\ThreadDetectorInterface;
 use Qameta\Allure\Io\DataSourceFactory;
 use Qameta\Allure\Model\EnvProvider;
+use Qameta\Allure\Model\FixtureResult;
 use Qameta\Allure\Model\ModelProviderChain;
 use Qameta\Allure\Model\Parameter;
 use Qameta\Allure\Model\ResultFactoryInterface;
@@ -42,6 +45,8 @@ final class TestLifecycle implements TestLifecycleInterface
 
     private ?StepStartInfo $currentStepStart = null;
 
+    private bool $suiteHookContext = false;
+
     /**
      * @psalm-var WeakMap<Step, StepStartInfo>
      */
@@ -55,6 +60,7 @@ final class TestLifecycle implements TestLifecycleInterface
         private ThreadDetectorInterface $threadDetector,
         private LinkTemplateCollectionInterface $linkTemplates,
         private array $env,
+        private AllureAdapterInterface $adapter,
     ) {
         /** @psalm-var WeakMap<Step, StepStartInfo> $this->stepStarts */
         $this->stepStarts = new WeakMap();
@@ -92,6 +98,7 @@ final class TestLifecycle implements TestLifecycleInterface
     public function resetSuite(): self
     {
         $this->currentSuite = null;
+        $this->suiteHookContext = false;
 
         return $this;
     }
@@ -102,6 +109,7 @@ final class TestLifecycle implements TestLifecycleInterface
         $thread = $this->threadDetector->getThread();
         $this->lifecycle->switchThread($thread);
 
+        $this->suiteHookContext = false;
         $this->currentTest = $this
             ->getTestInfoBuilder($test)
             ->build(
@@ -136,6 +144,7 @@ final class TestLifecycle implements TestLifecycleInterface
             containerUuid: $containerResult->getUuid(),
             testUuid: $testResult->getUuid(),
         );
+        $this->adapter->clearTestStarted($testResult->getUuid());
 
         return $this;
     }
@@ -180,7 +189,9 @@ final class TestLifecycle implements TestLifecycleInterface
     #[\Override]
     public function startTest(): self
     {
-        $this->lifecycle->startTest($this->getCurrentTestStart()->getTestUuid());
+        $testUuid = $this->getCurrentTestStart()->getTestUuid();
+        $this->lifecycle->startTest($testUuid);
+        $this->adapter->markTestStarted($testUuid);
 
         return $this;
     }
@@ -188,6 +199,8 @@ final class TestLifecycle implements TestLifecycleInterface
     #[\Override]
     public function stopTest(): self
     {
+        $this->completeHookFixtureSuccess();
+
         $testUuid = $this->getCurrentTestStart()->getTestUuid();
         $this
             ->lifecycle
@@ -200,6 +213,7 @@ final class TestLifecycle implements TestLifecycleInterface
             ->stopContainer($containerUuid);
         $this->lifecycle->writeContainer($containerUuid);
 
+        $this->adapter->clearTestStarted($testUuid);
         $this->currentTest = null;
         $this->currentTestStart = null;
 
@@ -388,5 +402,196 @@ final class TestLifecycle implements TestLifecycleInterface
         );
 
         return $this;
+    }
+
+    #[\Override]
+    public function ensureSuiteContainer(): self
+    {
+        $suite = $this->getCurrentSuite();
+        $this->suiteHookContext = true;
+
+        if ($this->adapter->getSuiteContainerId($suite->getName()) !== null) {
+            return $this;
+        }
+
+        $containerResult = $this->resultFactory->createContainer();
+        $this->lifecycle->startContainer($containerResult);
+        $this->adapter->registerSuiteContainer($suite->getName(), $containerResult->getUuid());
+
+        return $this;
+    }
+
+    #[\Override]
+    public function writeSuiteContainer(): self
+    {
+        $suite = $this->currentSuite;
+        if ($suite === null) {
+            return $this;
+        }
+
+        $containerId = $this->adapter->getSuiteContainerId($suite->getName());
+        if ($containerId === null) {
+            return $this;
+        }
+
+        $this->completeHookFixtureSuccess();
+        $this->lifecycle->stopContainer($containerId);
+        $this->lifecycle->writeContainer($containerId);
+        $this->adapter->clearSuiteContainer($suite->getName());
+        $this->suiteHookContext = false;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function startBeforeHookFixture(string $hookName): self
+    {
+        return $this->startHookFixture($hookName, before: true);
+    }
+
+    #[\Override]
+    public function startAfterHookFixture(string $hookName): self
+    {
+        return $this->startHookFixture($hookName, before: false);
+    }
+
+    #[\Override]
+    public function completeHookFixtureSuccess(): self
+    {
+        $uuid = $this->adapter->getActiveFixtureUuid();
+        if ($uuid === null) {
+            return $this;
+        }
+
+        $this->lifecycle->updateFixture(
+            static fn (FixtureResult $fixture) => $fixture->setStatus(Status::passed()),
+            $uuid,
+        );
+        $this->lifecycle->stopFixture($uuid);
+        $this->adapter->clearActiveFixture();
+
+        return $this;
+    }
+
+    #[\Override]
+    public function completeHookFixtureFailure(
+        Status $status,
+        ?string $message = null,
+        ?string $trace = null,
+    ): self {
+        $uuid = $this->adapter->getActiveFixtureUuid();
+        $hookName = $this->adapter->getActiveHookName() ?? 'hook';
+        if ($uuid === null) {
+            return $this;
+        }
+
+        $prefixed = HookFailureMessage::format($hookName, $message);
+
+        $this->lifecycle->updateFixture(
+            static function (FixtureResult $fixture) use ($status, $prefixed, $trace): void {
+                $fixture
+                    ->setStatus($status)
+                    ->setStatusDetails(
+                        (new StatusDetails())
+                            ->setMessage($prefixed)
+                            ->setTrace($trace),
+                    );
+            },
+            $uuid,
+        );
+        $this->lifecycle->stopFixture($uuid);
+
+        if (!$this->adapter->hasEmittedHookGlobalError($uuid)) {
+            Allure::globalError($prefixed, $trace);
+            $this->adapter->markHookGlobalErrorEmitted($uuid);
+        }
+
+        $this->adapter->clearActiveFixture();
+
+        return $this;
+    }
+
+    #[\Override]
+    public function completeOrphanHookFailure(
+        Status $status,
+        ?string $message = null,
+        ?string $trace = null,
+    ): self {
+        if ($this->currentTestStart === null) {
+            return $this;
+        }
+
+        if ($this->adapter->getActiveFixtureUuid() === null) {
+            return $this;
+        }
+
+        if ($this->adapter->wasTestStarted($this->getCurrentTestStart()->getTestUuid())) {
+            return $this;
+        }
+
+        $this->completeHookFixtureFailure($status, $message, $trace);
+
+        return $this;
+    }
+
+    #[\Override]
+    public function flushActiveHookFixtureFailure(
+        Status $status,
+        ?string $message = null,
+        ?string $trace = null,
+    ): self {
+        if ($this->adapter->getActiveFixtureUuid() === null) {
+            return $this;
+        }
+
+        $this->completeHookFixtureFailure($status, $message, $trace);
+
+        return $this;
+    }
+
+    #[\Override]
+    public function finalizePendingTest(): self
+    {
+        if ($this->currentTestStart === null) {
+            return $this;
+        }
+
+        $this->updateTestResult();
+        $this->stopTest();
+
+        return $this;
+    }
+
+    private function startHookFixture(string $hookName, bool $before): self
+    {
+        $this->completeHookFixtureSuccess();
+
+        $fixture = $this
+            ->resultFactory
+            ->createFixture()
+            ->setName($hookName);
+
+        $containerId = $this->resolveContainerId();
+        if ($before) {
+            $this->lifecycle->startBeforeFixture($fixture, $containerId);
+        } else {
+            $this->lifecycle->startAfterFixture($fixture, $containerId);
+        }
+
+        $this->adapter->setActiveFixture($fixture->getUuid(), $hookName);
+
+        return $this;
+    }
+
+    private function resolveContainerId(): string
+    {
+        if ($this->suiteHookContext) {
+            $suite = $this->getCurrentSuite();
+
+            return $this->adapter->getSuiteContainerId($suite->getName())
+                ?? throw new RuntimeException("Suite container is not set for {$suite->getName()}");
+        }
+
+        return $this->getCurrentTestStart()->getContainerUuid();
     }
 }

--- a/src/Internal/TestLifecycleInterface.php
+++ b/src/Internal/TestLifecycleInterface.php
@@ -46,4 +46,45 @@ interface TestLifecycleInterface
     public function updateStep(): TestLifecycleInterface;
 
     public function updateStepResult(): TestLifecycleInterface;
+
+    public function ensureSuiteContainer(): TestLifecycleInterface;
+
+    public function writeSuiteContainer(): TestLifecycleInterface;
+
+    public function startBeforeHookFixture(string $hookName): TestLifecycleInterface;
+
+    public function startAfterHookFixture(string $hookName): TestLifecycleInterface;
+
+    public function completeHookFixtureSuccess(): TestLifecycleInterface;
+
+    public function completeHookFixtureFailure(
+        Status $status,
+        ?string $message = null,
+        ?string $trace = null,
+    ): TestLifecycleInterface;
+
+    /**
+     * Completes an active before-hook fixture when Module throws and the low-priority
+     * stop listener does not run; failure surfaces as TEST_ERROR / TEST_FAIL.
+     */
+    public function completeOrphanHookFailure(
+        Status $status,
+        ?string $message = null,
+        ?string $trace = null,
+    ): TestLifecycleInterface;
+
+    /**
+     * Completes a still-active after-hook fixture (e.g. Module::_after threw and
+     * TEST_END was skipped) before suite teardown.
+     */
+    public function flushActiveHookFixtureFailure(
+        Status $status,
+        ?string $message = null,
+        ?string $trace = null,
+    ): TestLifecycleInterface;
+
+    /**
+     * Writes the current test/container when TEST_END was skipped (e.g. `_after` threw).
+     */
+    public function finalizePendingTest(): TestLifecycleInterface;
 }

--- a/test/codeception/unit/HookFailureIntegrationTest.php
+++ b/test/codeception/unit/HookFailureIntegrationTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Unit;
+
+use Codeception\Test\Unit;
+
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function array_values;
+use function dirname;
+use function fclose;
+use function file_get_contents;
+use function getenv;
+use function glob;
+use function implode;
+use function is_array;
+use function is_resource;
+use function json_encode;
+use function mkdir;
+use function preg_split;
+use function proc_close;
+use function proc_open;
+use function sprintf;
+use function stream_get_contents;
+use function str_starts_with;
+use function sys_get_temp_dir;
+use function trim;
+use function uniqid;
+
+use const JSON_THROW_ON_ERROR;
+use const PHP_BINARY;
+
+/**
+ * Runs hook-failure fixtures in a Codeception subprocess and asserts
+ * Allure fixtures + globals.
+ *
+ * Aggregate Module (+ beforeClass folded in) phases only — cannot split
+ * Module vs @beforeClass with the extension alone.
+ *
+ * Not covered (no Codeception events):
+ * - Cest `_before` / `_after` / `@before` / `@after` (inside Cest::test())
+ * - Unit setUp/tearDown (inside PHPUnit case)
+ * - Step hooks / Module `_failed`
+ */
+final class HookFailureIntegrationTest extends Unit
+{
+    /**
+     * @dataProvider providerHookFailures
+     */
+    public function testHookFailure_EmitsFixtureAndSinglePrefixedGlobal(
+        string $hookName,
+        string $mode,
+        string $messagePrefix,
+        string $fixtureStatus,
+    ): void {
+        $outputDir = sys_get_temp_dir() . '/allure-codeception-hook-int-' . uniqid('', true);
+        mkdir($outputDir);
+
+        [$output, $exitCode] = $this->runHookSuite($outputDir, $hookName, $mode);
+        self::assertNotSame(0, $exitCode, implode("\n", $output));
+
+        $globals = $this->readGlobalMessages($outputDir);
+        $matching = array_values(array_filter(
+            $globals,
+            static fn (string $message): bool => str_starts_with($message, $messagePrefix),
+        ));
+        self::assertCount(
+            1,
+            $matching,
+            sprintf(
+                "Expected one global starting with %s, got: %s\nCodecept output:\n%s",
+                $messagePrefix,
+                (string) json_encode($globals),
+                implode("\n", $output),
+            ),
+        );
+
+        $fixtures = $this->readFixturesNamed($outputDir, $hookName);
+        self::assertNotEmpty($fixtures, "Expected fixture named {$hookName}\n" . implode("\n", $output));
+        $statuses = array_map(
+            static fn (array $fixture): ?string => $fixture['status'] ?? null,
+            $fixtures,
+        );
+        self::assertContains($fixtureStatus, $statuses, (string) json_encode($fixtures));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, string}>
+     */
+    public static function providerHookFailures(): iterable
+    {
+        yield 'before throw' => ['_before', 'throw', '_before failed', 'broken'];
+        yield 'after throw' => ['_after', 'throw', '_after failed', 'broken'];
+        yield 'beforeSuite throw' => ['_beforeSuite', 'throw', '_beforeSuite failed', 'broken'];
+        yield 'afterSuite throw' => ['_afterSuite', 'throw', '_afterSuite failed', 'broken'];
+        yield 'before assertion' => ['_before', 'assert', '_before failed', 'failed'];
+        yield 'before empty message' => ['_before', 'empty', '_before failed', 'broken'];
+    }
+
+    /**
+     * Runs the hooks-fixtures suite with env overrides (OS-safe; no shell VAR=value).
+     *
+     * @return array{0: list<string>, 1: int}
+     */
+    private function runHookSuite(string $outputDir, string $hookName, string $mode): array
+    {
+        $root = dirname(__DIR__, 3);
+        $cmd = [
+            PHP_BINARY,
+            $root . '/vendor/bin/codecept',
+            'run',
+            'unit',
+            '-c',
+            $root . '/codeception-hooks.yml',
+            '--no-colors',
+        ];
+
+        $env = array_merge(
+            getenv(),
+            [
+                'ALLURE_HOOK_OUTPUT' => $outputDir,
+                'ALLURE_HOOK_FAIL' => $hookName,
+                'ALLURE_HOOK_MODE' => $mode,
+            ],
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $proc = proc_open($cmd, $descriptors, $pipes, $root, $env);
+        self::assertTrue(is_resource($proc), 'Failed to start codecept subprocess');
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($proc);
+
+        $combined = trim(($stdout === false ? '' : $stdout) . "\n" . ($stderr === false ? '' : $stderr));
+        $split = $combined === '' ? false : preg_split("/\r\n|\n|\r/", $combined);
+        $lines = $split === false ? [] : $split;
+
+        return [$lines, $exitCode];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readGlobalMessages(string $outputDir): array
+    {
+        $messages = [];
+        $files = glob($outputDir . '/*-globals.json');
+        if (!is_array($files)) {
+            return [];
+        }
+
+        foreach ($files as $file) {
+            /** @var array{errors?: list<array{message?: string}>} $data */
+            $data = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($data['errors'] ?? [] as $error) {
+                if (isset($error['message'])) {
+                    $messages[] = $error['message'];
+                }
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
+     * @return list<array{name?: string, status?: string}>
+     */
+    private function readFixturesNamed(string $outputDir, string $hookName): array
+    {
+        $fixtures = [];
+        $files = glob($outputDir . '/*-container.json');
+        if (!is_array($files)) {
+            return [];
+        }
+
+        foreach ($files as $file) {
+            /**
+             * @var array{
+             *     befores?: list<array{name?: string, status?: string}>,
+             *     afters?: list<array{name?: string, status?: string}>
+             * } $data
+             */
+            $data = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            foreach ([...($data['befores'] ?? []), ...($data['afters'] ?? [])] as $fixture) {
+                if (($fixture['name'] ?? null) === $hookName) {
+                    $fixtures[] = $fixture;
+                }
+            }
+        }
+
+        return $fixtures;
+    }
+}

--- a/test/codeception/unit/Internal/HookFailureMessageTest.php
+++ b/test/codeception/unit/Internal/HookFailureMessageTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Unit\Internal;
+
+use Codeception\Test\Unit;
+use Qameta\Allure\Codeception\Internal\HookFailureMessage;
+
+final class HookFailureMessageTest extends Unit
+{
+    /**
+     * @dataProvider providerFormat
+     */
+    public function testFormat_MessageVariants_ReturnsPrefixedOrFallback(
+        string $hookName,
+        ?string $original,
+        string $expected,
+    ): void {
+        self::assertSame($expected, HookFailureMessage::format($hookName, $original));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, string}>
+     */
+    public static function providerFormat(): iterable
+    {
+        yield 'with details' => ['_before', 'boom', '_before failed: boom'];
+        yield 'empty string' => ['_before', '', '_before failed'];
+        yield 'whitespace only' => ['_after', "  \t  ", '_after failed'];
+        yield 'null' => ['_beforeSuite', null, '_beforeSuite failed'];
+        yield 'assertion message' => [
+            '_before',
+            'Failed asserting that false is true.',
+            '_before failed: Failed asserting that false is true.',
+        ];
+    }
+}

--- a/test/codeception/unit/Internal/TestLifecycleHookFixtureTest.php
+++ b/test/codeception/unit/Internal/TestLifecycleHookFixtureTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Unit\Internal;
+
+use Codeception\Test\Unit;
+use Qameta\Allure\Allure;
+use Qameta\Allure\Codeception\AllureAdapter;
+use Qameta\Allure\Codeception\Internal\DefaultThreadDetector;
+use Qameta\Allure\Codeception\Internal\SuiteInfo;
+use Qameta\Allure\Codeception\Internal\TestLifecycle;
+use Qameta\Allure\Model\Status;
+
+use function file_get_contents;
+use function glob;
+use function is_array;
+use function json_decode;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Unit coverage for fixture success/failure + global error emission.
+ *
+ * Not covered here (no Codeception events for these): Cest `_before` / `_after` /
+ * `@before` / `@after` (run inside Cest::test()), Unit setUp/tearDown (inside
+ * PHPUnit case), step hooks, and Module `_failed`.
+ */
+final class TestLifecycleHookFixtureTest extends Unit
+{
+    private string $outputDirectory;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Allure::reset();
+        AllureAdapter::reset();
+        $this->outputDirectory = sys_get_temp_dir() . '/allure-codeception-hook-' . uniqid('', true);
+        mkdir($this->outputDirectory);
+        Allure::getLifecycleConfigurator()->setOutputDirectory($this->outputDirectory);
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Allure::reset();
+        AllureAdapter::reset();
+        parent::tearDown();
+    }
+
+    public function testCompleteHookFixtureFailure_EmitsPrefixedGlobalAndStopsFixture(): void
+    {
+        $lifecycle = $this->createLifecycle();
+        $lifecycle
+            ->switchToSuite(new SuiteInfo('unit'))
+            ->switchToTest($this)
+            ->create()
+            ->startBeforeHookFixture('_before');
+        $lifecycle->completeHookFixtureFailure(Status::broken(), 'boom', 'trace-line');
+
+        $globals = $this->readGlobalErrors();
+        self::assertCount(1, $globals);
+        self::assertSame('_before failed: boom', $globals[0]['message'] ?? null);
+        self::assertSame('trace-line', $globals[0]['trace'] ?? null);
+    }
+
+    public function testCompleteHookFixtureFailure_BlankMessage_UsesFallback(): void
+    {
+        $lifecycle = $this->createLifecycle();
+        $lifecycle
+            ->switchToSuite(new SuiteInfo('unit'))
+            ->switchToTest($this)
+            ->create()
+            ->startBeforeHookFixture('_before');
+        $lifecycle->completeHookFixtureFailure(Status::failed(), '   ', null);
+
+        $globals = $this->readGlobalErrors();
+        self::assertCount(1, $globals);
+        self::assertSame('_before failed', $globals[0]['message'] ?? null);
+    }
+
+    public function testCompleteHookFixtureFailure_CalledTwice_DoesNotDuplicateGlobal(): void
+    {
+        $lifecycle = $this->createLifecycle();
+        $lifecycle
+            ->switchToSuite(new SuiteInfo('unit'))
+            ->switchToTest($this)
+            ->create()
+            ->startBeforeHookFixture('_before');
+
+        $adapter = AllureAdapter::getInstance();
+        $uuid = $adapter->getActiveFixtureUuid();
+        self::assertNotNull($uuid);
+
+        $lifecycle->completeHookFixtureFailure(Status::broken(), 'once', 't');
+        $adapter->setActiveFixture($uuid, '_before');
+        $lifecycle->completeHookFixtureFailure(Status::broken(), 'twice', 't');
+
+        $globals = $this->readGlobalErrors();
+        self::assertCount(1, $globals);
+        self::assertSame('_before failed: once', $globals[0]['message'] ?? null);
+    }
+
+    public function testCompleteHookFixtureSuccess_MarksFixturePassed(): void
+    {
+        $lifecycle = $this->createLifecycle();
+        $lifecycle
+            ->switchToSuite(new SuiteInfo('unit'))
+            ->switchToTest($this)
+            ->create()
+            ->startBeforeHookFixture('_before')
+            ->completeHookFixtureSuccess()
+            ->startTest()
+            ->stopTest();
+
+        $fixtures = $this->readFixturesNamed('_before');
+        self::assertNotEmpty($fixtures);
+        self::assertSame('passed', $fixtures[0]['status'] ?? null);
+    }
+
+    private function createLifecycle(): TestLifecycle
+    {
+        return new TestLifecycle(
+            rootDir: getcwd() ?: '/',
+            lifecycle: Allure::getLifecycle(),
+            resultFactory: Allure::getConfig()->getResultFactory(),
+            statusDetector: Allure::getConfig()->getStatusDetector(),
+            threadDetector: new DefaultThreadDetector(),
+            linkTemplates: Allure::getConfig()->getLinkTemplates(),
+            env: [],
+            adapter: AllureAdapter::getInstance(),
+        );
+    }
+
+    /**
+     * @return list<array{message?: string, trace?: string}>
+     */
+    private function readGlobalErrors(): array
+    {
+        $files = glob($this->outputDirectory . '/*-globals.json');
+        if (!is_array($files)) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($files as $file) {
+            /** @var array{errors?: list<array{message?: string, trace?: string}>} $data */
+            $data = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($data['errors'] ?? [] as $error) {
+                $errors[] = $error;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<array{name?: string, status?: string}>
+     */
+    private function readFixturesNamed(string $hookName): array
+    {
+        $fixtures = [];
+        $files = glob($this->outputDirectory . '/*-container.json');
+        if (!is_array($files)) {
+            return [];
+        }
+
+        foreach ($files as $file) {
+            /**
+             * @var array{
+             *     befores?: list<array{name?: string, status?: string}>,
+             *     afters?: list<array{name?: string, status?: string}>
+             * } $data
+             */
+            $data = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            foreach ([...($data['befores'] ?? []), ...($data['afters'] ?? [])] as $fixture) {
+                if (($fixture['name'] ?? null) === $hookName) {
+                    $fixtures[] = $fixture;
+                }
+            }
+        }
+
+        return $fixtures;
+    }
+}

--- a/test/hooks-fixtures/_support/Helper/HookFailHelper.php
+++ b/test/hooks-fixtures/_support/Helper/HookFailHelper.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Hooks\Helper;
+
+use Codeception\Module;
+use Codeception\TestInterface;
+use PHPUnit\Framework\Assert;
+use RuntimeException;
+
+/**
+ * Module hooks controlled by ALLURE_HOOK_FAIL / ALLURE_HOOK_MODE env vars.
+ *
+ * Aggregate Module phase only — cannot split Module vs @beforeClass via extension.
+ */
+final class HookFailHelper extends Module
+{
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+    public function _beforeSuite(array $settings = []): void
+    {
+        $this->maybeFail('_beforeSuite');
+    }
+
+    public function _afterSuite(): void
+    {
+        $this->maybeFail('_afterSuite');
+    }
+
+    public function _before(TestInterface $test): void
+    {
+        $this->maybeFail('_before');
+    }
+
+    public function _after(TestInterface $test): void
+    {
+        $this->maybeFail('_after');
+    }
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
+
+    private function maybeFail(string $hookName): void
+    {
+        $target = getenv('ALLURE_HOOK_FAIL');
+        if ($target !== $hookName) {
+            return;
+        }
+
+        $mode = getenv('ALLURE_HOOK_MODE') ?: 'throw';
+        match ($mode) {
+            'assert' => Assert::fail("{$hookName} assertion"),
+            'empty' => throw new RuntimeException(''),
+            default => throw new RuntimeException("{$hookName} boom"),
+        };
+    }
+}

--- a/test/hooks-fixtures/_support/Setup/OutputDirectoryHook.php
+++ b/test/hooks-fixtures/_support/Setup/OutputDirectoryHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Hooks\Setup;
+
+use Qameta\Allure\Allure;
+
+/**
+ * Resolves ALLURE_HOOK_OUTPUT for subprocess integration runs.
+ */
+final class OutputDirectoryHook
+{
+    public function __invoke(): void
+    {
+        $output = getenv('ALLURE_HOOK_OUTPUT');
+        if ($output === false || $output === '') {
+            return;
+        }
+
+        Allure::getLifecycleConfigurator()->setOutputDirectory($output);
+    }
+}

--- a/test/hooks-fixtures/_support/UnitTester.php
+++ b/test/hooks-fixtures/_support/UnitTester.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Hooks;
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+}

--- a/test/hooks-fixtures/unit.suite.yml
+++ b/test/hooks-fixtures/unit.suite.yml
@@ -1,0 +1,4 @@
+actor: UnitTester
+modules:
+  enabled:
+    - \Qameta\Allure\Codeception\Test\Hooks\Helper\HookFailHelper

--- a/test/hooks-fixtures/unit/PassingCest.php
+++ b/test/hooks-fixtures/unit/PassingCest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Codeception\Test\Hooks;
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * Minimal passing body used by hook-failure subprocess suites.
+ *
+ * Not covered by extension events (documented exclusion):
+ * - Cest `_before` / `_after` / `@before` / `@after` (inside Cest::test())
+ * - Unit setUp/tearDown (inside PHPUnit case)
+ * - Step hooks / Module `_failed`
+ */
+final class PassingCest
+{
+    public function testPass(UnitTester $I): void
+    {
+        Assert::assertTrue(true);
+    }
+}


### PR DESCRIPTION
When a Codeception **module hook** fails (`_before`, `_after`, `_beforeSuite`, `_afterSuite`), Allure often missed a clear run-level signal — especially for suite setup failures.

This change aligns Codeception with the rest of the Allure ecosystem:

1. Record those hooks as **fixtures** in the report (so setup/teardown stays visible).
2. On failure, also write an Allure **global error**, so the failure shows under **Global Errors**.

Existing test results keep working the same way; we only add fixture + global-error reporting for the hooks we wrap.

- Hook failures are easy to overlook in Allure if they only leave a broken/incomplete test story.
- Global Errors give a single, obvious place to see “setup/teardown blew up.”
- Fixture reporting keeps the before/after context next to the suite or test container.

## Behavior

- Supported hooks: Module `_beforeSuite`, `_afterSuite`, `_before`, `_after`.
- On failure: fixture is marked failed/broken **and** one global error is written (no duplicates).
- Global error message: `{hook} failed: …`, or `{hook} failed` when there is no useful message.
- Test reporting starts after `_before` succeeds (same idea as allure-phpunit), so a failing before-hook does not look like a half-started test.